### PR TITLE
Compatibility with SetURL widget

### DIFF
--- a/src/DynamicImage/widget/DynamicImage.js
+++ b/src/DynamicImage/widget/DynamicImage.js
@@ -143,7 +143,11 @@ define([
             logger.debug(this.id + "._setToDefaultImage");
             if (this._imageNode) {
                 this._imageNode.onerror = null; //do not catch exceptions when loading default
-                this._imageNode.src = this.defaultImage;
+                if (this.defaultImage.indexOf('://') > 0 || this.defaultImage.indexOf('//') === 0) { // check if url is absolute
+                    this._imageNode.src = this.defaultImage;
+                } else {
+                    this._imageNode.src = window.location.origin + "/" + this.defaultImage;
+                }
                 this._setClickClass();
             }
         },

--- a/src/DynamicImage/widget/StaticImage.js
+++ b/src/DynamicImage/widget/StaticImage.js
@@ -30,7 +30,6 @@ define([
             logger.debug(this.id + "._updateRendering");
 
             if (this.imageurl !== "") {
-                this._imageNode.src = this.imageurl;
                 if (this.imageurl.indexOf('://') > 0 || this.imageurl.indexOf('//') === 0) { // check if url is absolute
                     this._imageNode.src = this.imageurl;
                 } else {

--- a/src/DynamicImage/widget/StaticImage.js
+++ b/src/DynamicImage/widget/StaticImage.js
@@ -31,8 +31,17 @@ define([
 
             if (this.imageurl !== "") {
                 this._imageNode.src = this.imageurl;
+                if (this.imageurl.indexOf('://') > 0 || this.imageurl.indexOf('//') === 0) { // check if url is absolute
+                    this._imageNode.src = this.imageurl;
+                } else {
+                    this._imageNode.src = window.location.origin + "/" + this.imageurl;
+                }
             } else {
-                this._imageNode.src = this.defaultImage;
+                if (this.defaultImage.indexOf('://') > 0 || this.defaultImage.indexOf('//') === 0) { // check if url is absolute
+                    this._imageNode.src = this.defaultImage;
+                } else {
+                    this._imageNode.src = window.location.origin + "/" + this.defaultImage;
+                }
             }
 
             this._executeCallback(callback, "_updateRendering");


### PR DESCRIPTION
Previously, when using a relative url as default url in this widget the image path gets appended to the browser url. This is a problem when the seturl widget changes the url.